### PR TITLE
check if a symbolic link already exists

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,6 @@ runs:
         test $version = latest && version=$(wget -q -O- https://api.github.com/repos/rui314/mold/releases/latest | jq -r .tag_name | sed 's/^v//'); true
         echo "mold $version"
         wget -q -O- https://github.com/rui314/mold/releases/download/v$version/mold-$version-$(uname -m)-linux.tar.gz | sudo tar -C /usr/local --strip-components=1 -xzf -
-        test ${{ inputs.make-default }} = true && sudo ln -sf /usr/local/bin/mold $(realpath /usr/bin/ld); true
+        test ${{ inputs.make-default }} = true -a "$(realpath /usr/bin/ld)" != "/usr/local/bin/mold" && sudo ln -sf /usr/local/bin/mold $(realpath /usr/bin/ld); true
       shell: bash
       if: runner.os == 'linux'


### PR DESCRIPTION
Fix #4

Add check before creating symbolic link to prevent `ln` command failure