### PR TITLE
Use older Curl command line options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
         version=${{ inputs.mold-version }}
         test $version = latest && version=1.9.0
         echo "mold $version"
-        curl -L --retry 10 --no-progress-meter https://github.com/rui314/mold/releases/download/v$version/mold-$version-$(uname -m)-linux.tar.gz | sudo tar -C /usr/local --strip-components=1 -xzf -
+        curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v$version/mold-$version-$(uname -m)-linux.tar.gz | sudo tar -C /usr/local --strip-components=1 -xzf -
         test ${{ inputs.make-default }} = true -a "$(realpath /usr/bin/ld)" != /usr/local/bin/mold && sudo ln -sf /usr/local/bin/mold "$(realpath /usr/bin/ld)"; true
       shell: bash
       if: runner.os == 'linux'


### PR DESCRIPTION
For Reasons™, we are using this action with the deprecated Ubuntu 18.04 image, which only comes with [curl 7.58](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu1804-Readme.md). Unfortunately, that version of curl doesn't include the `--no-progress-meter` option. Using the combo of `--silent` and `--show-error` should be roughly equivalent.
