### PR TITLE
chore - simplify linking step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,7 @@ runs:
     - run: |
         echo "mold ${{ inputs.mold-version }}"
         curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v${{ inputs.mold-version }}/mold-${{ inputs.mold-version }}-$(uname -m)-linux.tar.gz | sudo tar -C /usr/local --strip-components=1 -xzf -
-        test ${{ inputs.make-default }} = true -a "$(realpath /usr/bin/ld)" != /usr/local/bin/mold && sudo ln -sf /usr/local/bin/mold "$(realpath /usr/bin/ld)"; true
+        echo "${{ inputs.make-default }}"
+        sudo ln -sf /usr/local/bin/mold "$(realpath /usr/bin/ld)"
       shell: bash
       if: runner.os == 'linux'


### PR DESCRIPTION
- `echo "${{ inputs.make-default }}"` to respect the same standard as the step just before.

- `true -a "$(realpath /usr/bin/ld)" != /usr/local/bin/mold` will always evaluate to false as `mold` is not yet included by default in popular systems. As a result I believe we can let this line go.

- `sudo ln -sf /usr/local/bin/mold "$(realpath /usr/bin/ld)"` can be its own line as it should always evaluate to true and if it cannot force link for some reasons we want to be notified.